### PR TITLE
Update cats-effect to 1.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val docs = project.in(file("docs"))
   .dependsOn(core)
 
 val catsV = "1.1.0"
-val catsEffectV = "0.10.1"
+val catsEffectV = "1.0.0-RC2"
 val scalazV = "7.2.23"
 
 // check for library updates whenever the project is [re]load

--- a/core/src/main/scala/io/chrisdavenport/scalaz/task/instances/TaskInstances.scala
+++ b/core/src/main/scala/io/chrisdavenport/scalaz/task/instances/TaskInstances.scala
@@ -1,14 +1,16 @@
 package io.chrisdavenport.scalaz.task.instances
 
-import cats.effect.{Effect, IO}
-import scalaz.\/
-import scalaz.concurrent.Task
+import cats.effect.{Effect, ExitCase, IO}
+import cats.StackSafeMonad
+import scalaz.{\/, -\/, \/-}
+import scalaz.concurrent.{Future, Task}
+import scala.util.{Left, Right}
 import java.util.concurrent.atomic.AtomicBoolean
 
 object TaskInstances extends TaskInstances
 
 trait TaskInstances {
-  implicit val taskEffect: Effect[Task] = new Effect[Task] {
+  implicit val taskEffect: Effect[Task] = new Effect[Task] with StackSafeMonad[Task] {
 
     // Members declared in cats.Applicative
     def pure[A](x: A): Task[A] = Task.now(x)
@@ -18,15 +20,22 @@ trait TaskInstances {
       fa.handleWith(functionToPartial(f))
     def raiseError[A](e: Throwable): Task[A] = Task.fail(e)
 
+    // Members declared in cats.effect.Bracket
+    def bracketCase[A, B](acq: Task[A])(use: A => Task[B])(rel: (A, ExitCase[Throwable]) => Task[Unit]): Task[B] =
+      acq flatMap { a =>
+        use(a).onFinish(err =>
+          rel(a, err.fold(ExitCase.complete[Throwable])(ExitCase.error)))
+      }
+
     // Members declared in cats.effect.Async
     // In order to comply with `repeatedCallbackIgnored` law
     // on async, a custom AtomicBoolean is required to ignore
     // second callbacks.
     def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] =
-      Task.async { registered =>
-        val a = new AtomicBoolean(true)
-        k(e => if (a.getAndSet(false)) { registered(\/.fromEither(e)) } else ())
-      }
+      Task.async(singleUseCallback(k))
+
+    def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
+      Task.async(cb => singleUseCallback(k)(cb).unsafePerformSync)
 
     // Members declared in cats.effect.Effect
 
@@ -45,13 +54,20 @@ trait TaskInstances {
         }
       )
 
+    def runSyncStep[A](fa: Task[A]): IO[Either[Task[A], A]] =
+      IO(fa.get match {
+        case Future.Now(-\/(_)) => Left(fa)
+        case other => other.step match {
+          case Future.Now(\/-(a)) => Right(a)
+          case other              => Left(new Task(other))
+        }
+      })
+
+    override def toIO[A](fa: Task[A]): IO[A] =
+      IO.async(cb => fa.unsafePerformAsync(d => cb(d.toEither)))
+
     // Members declared in cats.FlatMap
     def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
-    // Simplest Implementation I could think of
-    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] = f(a).flatMap {
-      case Left(a) => tailRecM(a)(f)
-      case Right(b) => Task.now(b)
-    }
 
     // Members declared in cats.effect.Sync
     def suspend[A](thunk: => Task[A]): Task[A] = Task.suspend(thunk)
@@ -59,5 +75,12 @@ trait TaskInstances {
 
   private def functionToPartial[A, B](f: Function1[A, B]): PartialFunction[A, B] = _ match {
     case a => f(a)
+  }
+
+  private def singleUseCallback[A, B](
+      f: (Either[Throwable, A] => Unit) => B)
+      : (Throwable \/ A => Unit) => B = { registered =>
+    val a = new AtomicBoolean(true)
+    f(e => if (a.getAndSet(false)) { registered(\/.fromEither(e)) } else ())
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskArbitrary.scala
+++ b/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskArbitrary.scala
@@ -11,7 +11,6 @@ object TaskArbitrary {
   def genTask[A: Arbitrary: Cogen]: Gen[Task[A]] = {
     Gen.frequency(
       5 -> genPure[A],
-      5 -> genApply[A],
       1 -> genFail[A],
       5 -> genAsync[A],
       5 -> genNestedAsync[A],
@@ -23,9 +22,6 @@ object TaskArbitrary {
 
   def genPure[A: Arbitrary]: Gen[Task[A]] =
     Arbitrary.arbitrary[A].map(Task.now(_))
-
-  def genApply[A: Arbitrary]: Gen[Task[A]] =
-    Arbitrary.arbitrary[A].map(Task.apply(_))
 
   def genFail[A]: Gen[Task[A]] =
     Arbitrary.arbitrary[Throwable].map(Task.fail)
@@ -49,7 +45,7 @@ object TaskArbitrary {
           .flatMap(x => x))
 
   def genBindSuspend[A: Arbitrary: Cogen]: Gen[Task[A]] =
-    Arbitrary.arbitrary[A].map(Task.apply(_).flatMap(Task.now))
+    Arbitrary.arbitrary[A].map(Task.delay(_).flatMap(Task.now))
 
   def genFlatMap[A: Arbitrary: Cogen]: Gen[Task[A]] =
     for {

--- a/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskLaws.scala
+++ b/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskLaws.scala
@@ -1,6 +1,7 @@
 package io.chrisdavenport.scalaz.task
 
-import cats.effect.laws.discipline.EffectTests
+import cats.effect.laws.discipline.{EffectTests, Parameters}
+import cats.effect.laws.discipline.arbitrary._
 import org.typelevel.discipline.scalatest.Discipline
 import cats.effect.laws.util.TestContext
 import org.typelevel.discipline.Laws
@@ -52,6 +53,10 @@ class TaskLaws extends FunSuite with Matchers with Checkers with Discipline with
       }
   }
 
-  checkAllAsync("Effect[Task]", implicit e => EffectTests[Task].effect[Int, Int, Int])
+  implicit val taskParams: Parameters =
+    Parameters(
+      allowNonTerminationLaws = false,
+      stackSafeIterationsCount = 10000)
 
+  checkAllAsync("Task", implicit ec => EffectTests[Task].effect[Int, Int, Int])
 }


### PR DESCRIPTION
Updates `cats-effect` to `1.0.0-RC2` and adds missing implementations.

There are 3 laws that fail intermittently
* `runSyncStepRunAsyncConsistency`
* `toIORunAsyncConsistency`
* `toIOStackSafety`

I haven't been able to determine why. I've tried quite a few variations of implementations of `runAsync`/`runSyncStep`/`toIO` to no avail. I'm guessing one of them isn't quite correct, any ideas @ChristopherDavenport?