### PR TITLE
Update to cats-effect 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 
 scala:
-  - 2.12.6
+  - 2.12.7
   - 2.11.12
 
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,8 @@ lazy val docs = project.in(file("docs"))
   .dependsOn(core)
 
 val catsV = "1.4.0"
-val catsEffectV = "0.10.1"
-val scalazV = "7.2.23"
+val catsEffectV = "1.0.0"
+val scalazV = "7.2.26"
 
 // check for library updates whenever the project is [re]load
 onLoad in Global := { s =>
@@ -31,7 +31,7 @@ lazy val contributors = Seq(
 lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
 
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.7",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary),

--- a/core/src/main/scala/io/chrisdavenport/scalaz/task/instances/TaskInstances.scala
+++ b/core/src/main/scala/io/chrisdavenport/scalaz/task/instances/TaskInstances.scala
@@ -1,8 +1,9 @@
 package io.chrisdavenport.scalaz.task.instances
 
-import cats.effect.{Effect, IO}
-import scalaz.\/
+import cats.effect.{Effect, ExitCase, IO, SyncIO}
 import scalaz.concurrent.Task
+import scalaz.{-\/, \/, \/-}
+
 import java.util.concurrent.atomic.AtomicBoolean
 
 object TaskInstances extends TaskInstances
@@ -12,21 +13,33 @@ trait TaskInstances {
 
     // Members declared in cats.Applicative
     def pure[A](x: A): Task[A] = Task.now(x)
+    override def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+
+    // Members declared in cats.FlatMap
+    def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
+    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] = f(a).flatMap {
+      case Left(a) => tailRecM(a)(f)
+      case Right(b) => Task.now(b)
+    }
 
     // Members declared in cats.ApplicativeError
-    def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
-      fa.handleWith(functionToPartial(f))
     def raiseError[A](e: Throwable): Task[A] = Task.fail(e)
+    def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] =
+      fa.handleWith({ case e => f(e) })
+
+    // Members declared in cats.effect.Sync
+    def suspend[A](thunk: => Task[A]): Task[A] = Task.suspend(thunk)
 
     // Members declared in cats.effect.Async
+
     // In order to comply with `repeatedCallbackIgnored` law
     // on async, a custom AtomicBoolean is required to ignore
     // second callbacks.
     def async[A](k: (Either[Throwable, A] => Unit) => Unit): Task[A] =
-      Task.async { registered =>
-        val a = new AtomicBoolean(true)
-        k(e => if (a.getAndSet(false)) { registered(\/.fromEither(e)) } else ())
-      }
+      Task.async(registerCallback(k))
+
+    def asyncF[A](k: (Either[Throwable, A] => Unit) => Task[Unit]): Task[A] =
+      Task.async(registerCallback(k)(_).unsafePerformAsync(_ => ()))
 
     // Members declared in cats.effect.Effect
 
@@ -37,27 +50,28 @@ trait TaskInstances {
      * within the outer IO, discarding any error that might
      * occur
       **/
-    def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-      IO(
-        fa.unsafePerformAsync { disjunction =>
-          cb(disjunction.toEither)
-            .unsafeRunAsync(_ => ())
-        }
-      )
+    def runAsync[A](fa: Task[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+      SyncIO(fa.unsafePerformAsync(d => cb(d.toEither).unsafeRunAsyncAndForget()))
 
-    // Members declared in cats.FlatMap
-    def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
-    // Simplest Implementation I could think of
-    def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] = f(a).flatMap {
-      case Left(a) => tailRecM(a)(f)
-      case Right(b) => Task.now(b)
+    override def toIO[A](fa: Task[A]): IO[A] =
+      IO.async(k => fa.unsafePerformAsync(k.compose(_.toEither)))
+
+    // Members declared in cats.effect.Bracket
+
+    def bracketCase[A, B](acquire: Task[A])(use: A => Task[B])(
+        release: (A, ExitCase[Throwable]) => Task[Unit]
+    ): Task[B] = acquire.flatMap { a =>
+      use(a).attempt.flatMap {
+        case -\/(e) => release(a, ExitCase.error(e)).flatMap(_ => Task.fail(e))
+        case \/-(b) => release(a, ExitCase.complete).map(_ => b)
+      }
     }
 
-    // Members declared in cats.effect.Sync
-    def suspend[A](thunk: => Task[A]): Task[A] = Task.suspend(thunk)
-  }
-
-  private def functionToPartial[A, B](f: Function1[A, B]): PartialFunction[A, B] = _ match {
-    case a => f(a)
+    private def registerCallback[A, B](k: (Either[Throwable, A] => Unit) => B)(
+        registered: Throwable \/ A => Unit
+    ): B = {
+      val fence = new AtomicBoolean(true)
+      k(e => if (fence.getAndSet(false)) { registered(\/.fromEither(e)) })
+    }
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskArbitrary.scala
+++ b/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskArbitrary.scala
@@ -11,10 +11,10 @@ object TaskArbitrary {
   def genTask[A: Arbitrary: Cogen]: Gen[Task[A]] = {
     Gen.frequency(
       5 -> genPure[A],
-      5 -> genApply[A],
       1 -> genFail[A],
       5 -> genAsync[A],
       5 -> genNestedAsync[A],
+      5 -> genSuspend[A],
       5 -> getMapOne[A],
       5 -> getMapTwo[A],
       10 -> genFlatMap[A]
@@ -22,10 +22,7 @@ object TaskArbitrary {
   }
 
   def genPure[A: Arbitrary]: Gen[Task[A]] =
-    Arbitrary.arbitrary[A].map(Task.now(_))
-
-  def genApply[A: Arbitrary]: Gen[Task[A]] =
-    Arbitrary.arbitrary[A].map(Task.apply(_))
+    Arbitrary.arbitrary[A].map(Task.now)
 
   def genFail[A]: Gen[Task[A]] =
     Arbitrary.arbitrary[Throwable].map(Task.fail)
@@ -48,8 +45,8 @@ object TaskArbitrary {
           }
           .flatMap(x => x))
 
-  def genBindSuspend[A: Arbitrary: Cogen]: Gen[Task[A]] =
-    Arbitrary.arbitrary[A].map(Task.apply(_).flatMap(Task.now))
+  def genSuspend[A: Arbitrary: Cogen]: Gen[Task[A]] =
+    Arbitrary.arbitrary[Task[A]].map(Task.suspend(_))
 
   def genFlatMap[A: Arbitrary: Cogen]: Gen[Task[A]] =
     for {

--- a/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskLaws.scala
+++ b/core/src/test/scala/io/chrisdavenport/scalaz/task/TaskLaws.scala
@@ -1,19 +1,20 @@
 package io.chrisdavenport.scalaz.task
 
-import cats.effect.laws.discipline.EffectTests
-import org.typelevel.discipline.scalatest.Discipline
-import cats.effect.laws.util.TestContext
-import org.typelevel.discipline.Laws
+import cats.effect.laws.discipline.arbitrary._
+import cats.effect.laws.discipline.{EffectTests, Parameters}
+import cats.effect.laws.util.{TestContext, TestInstances}
+import cats.implicits._
+import io.chrisdavenport.scalaz.task.TaskArbitrary._
+import io.chrisdavenport.scalaz.task.TaskScalaCheckInstances._
 import org.scalatest.prop.Checkers
 import org.scalatest.{FunSuite, Matchers}
-import scala.util.control.NonFatal
-// import io.chrisdavenport.scalaz.task.instances.TaskInstances._ // Unnecessary because of Package Object
+import org.typelevel.discipline.Laws
+import org.typelevel.discipline.scalatest.Discipline
 import scalaz.concurrent.Task
-import TaskArbitrary._
-import TaskScalaCheckInstances._
+
 import java.io.{ByteArrayOutputStream, PrintStream}
-import cats.implicits._
-import cats.effect.laws.util.TestInstances
+
+import scala.util.control.NonFatal
 
 class TaskLaws extends FunSuite with Matchers with Checkers with Discipline with TestInstances {
 
@@ -52,6 +53,7 @@ class TaskLaws extends FunSuite with Matchers with Checkers with Discipline with
       }
   }
 
+  implicit val params: Parameters = Parameters.default.copy(allowNonTerminationLaws = false)
   checkAllAsync("Effect[Task]", implicit e => EffectTests[Task].effect[Int, Int, Int])
 
 }


### PR DESCRIPTION
Including some additional tweaks:

* Implement `asyncF` and `bracketCase`
* Reorder methods a bit
* Override `map` and `toIO` for performance
* Factor out `registerCallback`
* Update scala and scalaz